### PR TITLE
Replace cl with cl-lib

### DIFF
--- a/flyspell-lazy.el
+++ b/flyspell-lazy.el
@@ -181,7 +181,7 @@
 
 (eval-and-compile
   ;; for callf, callf2, setf
-  (require 'cl))
+  (require 'cl-lib))
 
 ;;; declarations
 


### PR DESCRIPTION
I believe this is all you need to avoid the warning Emacs 27 emits, as `cl-macs` defines aliases for `callf` and `callf2` and also pulls in `gv` which defines `setf`.